### PR TITLE
[tests/data/configs] add missing config

### DIFF
--- a/tests/data/configs/list-but-no-deployment/config.yml
+++ b/tests/data/configs/list-but-no-deployment/config.yml
@@ -1,0 +1,5 @@
+pagure:
+  - host: pagure.io
+    port: 32101
+  - host: stg.pagure.io
+    port: 32104


### PR DESCRIPTION
It's used in [unit/test_config.py](https://github.com/user-cont/frambo/blob/master/tests/unit/test_config.py#L105)