### PR TITLE
[Dockerfile] FROM fedora:29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Just a base image for bots, not supposed to be run on its own.
 
-FROM registry.fedoraproject.org/fedora:28
+FROM registry.fedoraproject.org/fedora:29
 
 ENV LANG=en_US.UTF-8
 


### PR DESCRIPTION
[Celery 4.3.0 now finally supports Python 3.7](http://docs.celeryproject.org/en/master/whatsnew-4.3.html)

I tested it with [example-bot](https://github.com/user-cont/frambo/tree/master/examples/bot) and seems to work OK.