### PR TITLE
Fixes #17 Initiate PAGURE_PORT to empty str

### DIFF
--- a/frambo/config.py
+++ b/frambo/config.py
@@ -11,6 +11,8 @@ import requests
 import sys
 import yaml
 
+from typing import Any
+
 from frambo.schemas import BotCfg
 
 BASE_PATH = Path(__file__).parent
@@ -52,11 +54,16 @@ def frambo_config(cfgdir=CONFIG_DIR):
     return config
 
 
-def get_from_frambo_config(module, key):
-    value = frambo_config().get(module, {}).get(key)
-    if not value:
+def get_from_frambo_config(
+    module: str,
+    key: str,
+    default: Any = "",
+    raises: bool = True,
+) -> str:
+
+    if key not in frambo_config().get(module, {}) and raises:
         raise ValueError(f"{module}:{key} not set in {CONFIG_DIR / 'config.yml'}")
-    return value
+    return frambo_config().get(module, {}).get(key, default)
 
 
 BOT_CONF_KEYS_ALIASES = get_from_frambo_config("config", "bot-conf-keys-aliases")

--- a/frambo/config.py
+++ b/frambo/config.py
@@ -59,7 +59,7 @@ def get_from_frambo_config(
     key: str,
     default: Any = "",
     raises: bool = True,
-) -> str:
+) -> Any:
 
     if key not in frambo_config().get(module, {}) and raises:
         raise ValueError(f"{module}:{key} not set in {CONFIG_DIR / 'config.yml'}")

--- a/frambo/pagure.py
+++ b/frambo/pagure.py
@@ -1,11 +1,7 @@
 from frambo.config import get_from_frambo_config
 
 PAGURE_HOST = get_from_frambo_config("pagure", "host")
-
-try:
-    PAGURE_PORT = get_from_frambo_config("pagure", "port")
-except ValueError:
-    PAGURE_PORT = ""
+PAGURE_PORT = get_from_frambo_config("pagure", "port", raises=False)
 
 PAGURE_URL = f"https://{PAGURE_HOST}/"
 

--- a/frambo/pagure.py
+++ b/frambo/pagure.py
@@ -1,7 +1,12 @@
 from frambo.config import get_from_frambo_config
 
 PAGURE_HOST = get_from_frambo_config("pagure", "host")
-PAGURE_PORT = get_from_frambo_config("pagure", "port")
+
+try:
+    PAGURE_PORT = get_from_frambo_config("pagure", "port")
+except ValueError:
+    PAGURE_PORT = ""
+
 PAGURE_URL = f"https://{PAGURE_HOST}/"
 
 


### PR DESCRIPTION
In case of a port is not defined
PAGURE_PORT is initiate to empty str.

Here is a snippet of failure:

```bash
betka_1      |   File "/home/betka/tasks.py", line 3, in <module>
betka_1      |     from betka.core import Betka
betka_1      |   File "/usr/local/lib/python3.7/site-packages/betka/core.py", line 18, in <module>
betka_1      |     from frambo.pagure import PAGURE_HOST, PAGURE_PORT, PAGURE_URL
betka_1      |   File "/usr/local/lib/python3.7/site-packages/frambo/pagure.py", line 4, in <module>
betka_1      |     PAGURE_PORT = get_from_frambo_config("pagure", "port")
betka_1      |   File "/usr/local/lib/python3.7/site-packages/frambo/config.py", line 58, in get_from_frambo_config
betka_1      |     raise ValueError(f"{module}:{key} not set in {CONFIG_DIR / 'config.yml'}")
betka_1      | ValueError: Couldn't import 'tasks': pagure:port not set in /usr/local/lib/python3.7/site-packages/frambo/data/conf.d/config.yml
```
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>